### PR TITLE
zooba's idea

### DIFF
--- a/src/obs-progress.cpp
+++ b/src/obs-progress.cpp
@@ -26,6 +26,7 @@ void updateSceneInfo();
 
 QTimer* _timer;
 QMap<obs_source_t*, QProgressBar*> _sources;
+obs_source_t* _currentSceneSource;
 
 QString progressBarTitleFormat = "'%1' Source   %2 / %3 / -%4";
 
@@ -68,14 +69,9 @@ void startTimer()
 
 void stopTimer()
 {
-	try
-	{
-		//_timer->stop();
-	}
-	catch (...)
-	{
-		// Empty
-	}
+	_timer->stop();
+	_sources.clear();
+	obs_source_release(_currentSceneSource);
 }
 
 void timerHit()
@@ -125,12 +121,19 @@ void updateSceneInfo()
 {
 	try
 	{
-		obs_source_t* currentSceneSource = obs_frontend_get_current_scene(); // This is the only call that increments the count, so we have to release it
-		const char* name = obs_source_get_name(currentSceneSource);
+		// Clean up the previous source/scenes
+		_sources.clear();
+		obs_source_release(_currentSceneSource);
+		_progressDockWidget->clearProgressBars();
 
-		obs_scene_t* currentScene = obs_scene_from_source(currentSceneSource);
-		obs_source_release(currentSceneSource);
+		// Retrieve the current scene
+		_currentSceneSource = obs_frontend_get_current_scene(); // This is the only call that increments the count, so we have to release it
+		const char* name = obs_source_get_name(_currentSceneSource);
 
+		obs_scene_t* currentScene = obs_scene_from_source(_currentSceneSource);
+		obs_source_release(_currentSceneSource);
+
+		// Iterate through the sources in the current scene and add progress bars for each
 		auto sceneItemsCallback = [](obs_scene_t* currentScene, obs_sceneitem_t* currentSceneItem, void* param)
 		{
 			obs_source_t* currentSceneItemSource = obs_sceneitem_get_source(currentSceneItem);
@@ -144,8 +147,6 @@ void updateSceneInfo()
 			return true;
 		};
 
-		_sources.clear();
-		_progressDockWidget->clearProgressBars();
 		obs_scene_enum_items(currentScene, sceneItemsCallback, static_cast<void*>(static_cast<scene_items_callback>(sceneItemsCallback)));
 
 		_progressDockWidget->setWindowTitle("Progress of '" + QString(name) + "'");

--- a/src/obs-progress.cpp
+++ b/src/obs-progress.cpp
@@ -77,7 +77,12 @@ void stopTimer()
 		_timer->stop();
 	}
 	_sources.clear();
-	obs_source_release(_currentSceneSource);
+
+	if (_currentSceneSource)
+	{
+		obs_source_release(_currentSceneSource);
+		_currentSceneSource = nullptr;
+	}
 }
 
 void timerHit()

--- a/src/obs-progress.cpp
+++ b/src/obs-progress.cpp
@@ -26,7 +26,7 @@ void timerHit();
 void updateSceneInfo();
 
 QTimer* _timer;
-QMap<obs_source_t*, ProgressSlider*> _sources;
+QMap<obs_source_t*, QProgressBar*> _sources;
 obs_source_t* _currentSceneSource;
 
 QString progressBarTitleFormat = "'%1' Source   %2 / %3 / -%4";

--- a/src/obs-progress.cpp
+++ b/src/obs-progress.cpp
@@ -159,7 +159,6 @@ void updateSceneInfo()
 		const char* name = obs_source_get_name(_currentSceneSource);
 
 		obs_scene_t* currentScene = obs_scene_from_source(_currentSceneSource);
-		obs_source_release(_currentSceneSource);
 
 		// Iterate through the sources in the current scene and add progress bars for each
 		auto sceneItemsCallback = [](obs_scene_t* currentScene, obs_sceneitem_t* currentSceneItem, void* param)

--- a/src/obs-progress.cpp
+++ b/src/obs-progress.cpp
@@ -72,7 +72,10 @@ void startTimer()
 
 void stopTimer()
 {
-	_timer->stop();
+	if (_timer->isActive())
+	{
+		_timer->stop();
+	}
 	_sources.clear();
 	obs_source_release(_currentSceneSource);
 }


### PR DESCRIPTION
Keep track of _currentSceneSource so that the our handle is not released until we're done with it.